### PR TITLE
feat: add shiba team command for agent teams management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ All output is JSON to stdout.
 | Command | Purpose | Key Flags |
 |---------|---------|-----------|
 | `shiba setup` | Interactive setup wizard (auth + preferences) | `--reset`, `--defaults`, `--skip-auth` |
-| `shiba init` | Initialize project config | `--force` |
+| `shiba init` | Initialize project config + generate CLAUDE.md | `--force`, `--skip-claude-md` |
 | `shiba tui` | Interactive task navigator | — |
 | `shiba ask <query>` | Get help on shiba usage | — |
 | `shiba branch name` | Generate branch name (no git operation) | `--key`, `--description`, `--type` |
@@ -197,10 +197,11 @@ All output is JSON to stdout.
 
 **shiba setup** guides the user through CLI authentication and preference configuration. Use `--reset` to reconfigure an existing environment, `--defaults` to skip prompts and apply defaults, or `--skip-auth` to skip CLI authentication.
 
-**shiba init** detects the GitLab project from git remote and creates `.shiba/config.json`:
+**shiba init** detects the repository from git remote, creates `.shiba/config.json`, and generates a project-level `CLAUDE.md` with shiba agent instructions:
 ```json
 { "repository": "group/project-name" }
 ```
+The generated `CLAUDE.md` section is wrapped in `<!-- shiba-agent:start -->` / `<!-- shiba-agent:end -->` markers. Running `shiba init` again updates only the managed section, preserving any custom content. Use `--skip-claude-md` to skip `CLAUDE.md` generation.
 
 **shiba tui** launches an interactive terminal UI to navigate your Jira issues.
 

--- a/src/packages/shared/src/config/global.ts
+++ b/src/packages/shared/src/config/global.ts
@@ -91,6 +91,7 @@ const FIGMA_DIR = join(DATA_DIR, "figma");
 const GLAB_DIR = join(DATA_DIR, "glab");
 const JIRA_DIR = join(DATA_DIR, "jira");
 const TICKETS_DIR = join(DATA_DIR, "tickets");
+const CUSTOM_AGENTS_DIR = join(DATA_DIR, "agents");
 
 export function getConfigDir(): string {
   return CONFIG_DIR;
@@ -173,6 +174,16 @@ export function ensureJiraDir(): void {
 export function ensureTicketsDir(): void {
   if (!existsSync(TICKETS_DIR)) {
     mkdirSync(TICKETS_DIR, { recursive: true });
+  }
+}
+
+export function getCustomAgentsDir(): string {
+  return CUSTOM_AGENTS_DIR;
+}
+
+export function ensureCustomAgentsDir(): void {
+  if (!existsSync(CUSTOM_AGENTS_DIR)) {
+    mkdirSync(CUSTOM_AGENTS_DIR, { recursive: true });
   }
 }
 

--- a/src/packages/shared/src/index.ts
+++ b/src/packages/shared/src/index.ts
@@ -33,6 +33,8 @@ export {
   ensureGlabDir,
   ensureJiraDir,
   ensureTicketsDir,
+  getCustomAgentsDir,
+  ensureCustomAgentsDir,
   getCurrentEnvironment,
   isDataInitialized,
 } from "./config/global.js";

--- a/src/tools/shiba-cli/src/commands/init.ts
+++ b/src/tools/shiba-cli/src/commands/init.ts
@@ -8,9 +8,17 @@ import {
   ensureProjectDirs,
   type ProjectConfig,
 } from "../config/project.js";
+import {
+  SHIBA_SECTION_START,
+  SHIBA_SECTION_END,
+  generateShibaSection,
+  type Platform,
+  type ClaudeMdOptions,
+} from "../templates/claude-md.js";
 
 interface InitOpts {
   force?: boolean;
+  skipClaudeMd?: boolean;
 }
 
 export async function init(opts: InitOpts): Promise<void> {
@@ -24,11 +32,19 @@ export async function init(opts: InitOpts): Promise<void> {
   }
 
   // Detect git remote
-  const repository = detectGitlabProject();
+  const remoteUrl = getRemoteUrl();
+
+  if (!remoteUrl) {
+    errorResponse("NO_GIT_REMOTE", "Could not detect project from git remote origin.", {
+      hint: "Ensure you have a git remote named 'origin'.",
+    });
+  }
+
+  const repository = parseProjectPath(remoteUrl!);
 
   if (!repository) {
-    errorResponse("NO_GIT_REMOTE", "Could not detect GitLab project from git remote origin.", {
-      hint: "Ensure you have a git remote named 'origin' pointing to GitLab.",
+    errorResponse("NO_GIT_REMOTE", "Could not parse project path from git remote origin.", {
+      hint: "Ensure you have a git remote named 'origin' pointing to GitHub or GitLab.",
     });
   }
 
@@ -43,11 +59,23 @@ export async function init(opts: InitOpts): Promise<void> {
   // Add .shiba/tasks/ to .gitignore if not present
   updateGitignore();
 
+  // Generate CLAUDE.md
+  let claudeMdResult: string = "skipped";
+  if (!opts.skipClaudeMd) {
+    const platform = detectPlatform(remoteUrl!);
+    claudeMdResult = generateAndWriteClaudeMd({
+      platform,
+      issueTracker: "jira",
+      repository: repository!,
+    });
+  }
+
   successResponse({
     message: "Initialized .shiba/config.json",
     config,
     path: configPath,
     configDir: getConfigDir(),
+    claudeMd: claudeMdResult,
   });
 }
 
@@ -76,43 +104,75 @@ function updateGitignore(): void {
   writeFileSync(gitignorePath, newContent);
 }
 
-function detectGitlabProject(): string | null {
+function getRemoteUrl(): string | null {
   try {
-    // Get remote URL
-    const remoteUrl = execSync("git remote get-url origin", { encoding: "utf-8" }).trim();
-
-    // Parse GitLab project path from various URL formats:
-    // - https://gitlab.example.com/group/subgroup/project.git
-    // - git@gitlab.example.com:group/subgroup/project.git
-    // - ssh://git@gitlab.example.com/group/project.git
-
-    let projectPath: string | null = null;
-
-    // HTTPS format
-    const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
-    if (httpsMatch) {
-      projectPath = httpsMatch[1];
-    }
-
-    // SSH format (git@host:path)
-    const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
-    if (sshMatch) {
-      projectPath = sshMatch[1];
-    }
-
-    // SSH format (ssh://git@host/path)
-    const sshUrlMatch = remoteUrl.match(/ssh:\/\/[^/]+\/(.+?)(?:\.git)?$/);
-    if (sshUrlMatch) {
-      projectPath = sshUrlMatch[1];
-    }
-
-    // Remove trailing .git if present
-    if (projectPath?.endsWith(".git")) {
-      projectPath = projectPath.slice(0, -4);
-    }
-
-    return projectPath;
+    return execSync("git remote get-url origin", { encoding: "utf-8" }).trim();
   } catch {
     return null;
   }
+}
+
+export function detectPlatform(remoteUrl: string): Platform {
+  const lower = remoteUrl.toLowerCase();
+  if (lower.includes("github")) return "github";
+  if (lower.includes("gitlab")) return "gitlab";
+  return "both";
+}
+
+function parseProjectPath(remoteUrl: string): string | null {
+  let projectPath: string | null = null;
+
+  // HTTPS format
+  const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    projectPath = httpsMatch[1];
+  }
+
+  // SSH format (git@host:path)
+  const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
+  if (sshMatch) {
+    projectPath = sshMatch[1];
+  }
+
+  // SSH format (ssh://git@host/path)
+  const sshUrlMatch = remoteUrl.match(/ssh:\/\/[^/]+\/(.+?)(?:\.git)?$/);
+  if (sshUrlMatch) {
+    projectPath = sshUrlMatch[1];
+  }
+
+  // Remove trailing .git if present
+  if (projectPath?.endsWith(".git")) {
+    projectPath = projectPath.slice(0, -4);
+  }
+
+  return projectPath;
+}
+
+function generateAndWriteClaudeMd(opts: ClaudeMdOptions): string {
+  const claudeMdPath = "CLAUDE.md";
+  const section = generateShibaSection(opts);
+
+  if (!existsSync(claudeMdPath)) {
+    writeFileSync(claudeMdPath, section);
+    return "created";
+  }
+
+  const existing = readFileSync(claudeMdPath, "utf-8");
+  const startIdx = existing.indexOf(SHIBA_SECTION_START);
+  const endIdx = existing.indexOf(SHIBA_SECTION_END);
+
+  // Both markers found — replace section between them
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const after = existing.slice(endIdx + SHIBA_SECTION_END.length);
+    // Trim trailing newline from after to avoid double newlines
+    const trimmedAfter = after.startsWith("\n") ? after.slice(1) : after;
+    writeFileSync(claudeMdPath, before + section + trimmedAfter);
+    return "updated";
+  }
+
+  // No markers (or corrupted — only one marker) — append
+  const separator = existing.endsWith("\n") ? "\n" : "\n\n";
+  writeFileSync(claudeMdPath, existing + separator + section);
+  return "appended";
 }

--- a/src/tools/shiba-cli/src/commands/team.ts
+++ b/src/tools/shiba-cli/src/commands/team.ts
@@ -1,0 +1,543 @@
+import {
+  successResponse,
+  errorResponse,
+  getRepoRoot,
+  getCustomAgentsDir,
+  ensureCustomAgentsDir,
+} from "@shiba-agent/shared";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  unlinkSync,
+  symlinkSync,
+  lstatSync,
+  mkdirSync,
+  renameSync,
+} from "fs";
+import { join, basename } from "path";
+import { homedir } from "os";
+
+// --- Agent frontmatter parsing ---
+
+interface AgentMeta {
+  name: string;
+  description: string;
+  tools: string;
+  model: string;
+  maxTurns: number;
+}
+
+function parseAgentFile(filePath: string): { meta: AgentMeta; body: string } {
+  const content = readFileSync(filePath, "utf-8");
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    return {
+      meta: { name: basename(filePath, ".md"), description: "", tools: "", model: "sonnet", maxTurns: 15 },
+      body: content,
+    };
+  }
+
+  const frontmatter = match[1];
+  const body = (match[2] ?? "").trim();
+  const meta: Record<string, string> = {};
+
+  for (const line of frontmatter.split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    let value = line.slice(colonIdx + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    meta[key] = value;
+  }
+
+  return {
+    meta: {
+      name: meta.name || basename(filePath, ".md"),
+      description: meta.description || "",
+      tools: meta.tools || "",
+      model: meta.model || "sonnet",
+      maxTurns: parseInt(meta.maxTurns || "15", 10),
+    },
+    body,
+  };
+}
+
+function generateAgentFile(meta: AgentMeta, body: string): string {
+  return `---\nname: ${meta.name}\ndescription: "${meta.description}"\ntools: ${meta.tools}\nmodel: ${meta.model}\nmaxTurns: ${meta.maxTurns}\n---\n\n${body}\n`;
+}
+
+// --- Agent discovery ---
+
+function getBuiltInAgentsDir(): string {
+  return join(getRepoRoot(), "src", "agents");
+}
+
+function getClaudeAgentsDir(): string {
+  return join(homedir(), ".claude", "agents");
+}
+
+interface AgentInfo {
+  name: string;
+  type: "built-in" | "custom";
+  model: string;
+  maxTurns: number;
+  description: string;
+  tools: string;
+  path: string;
+}
+
+function discoverAgents(): AgentInfo[] {
+  const agents: AgentInfo[] = [];
+
+  // Built-in agents
+  const builtInDir = getBuiltInAgentsDir();
+  if (existsSync(builtInDir)) {
+    for (const file of readdirSync(builtInDir).filter((f) => f.endsWith(".md"))) {
+      const filePath = join(builtInDir, file);
+      const { meta } = parseAgentFile(filePath);
+      agents.push({
+        name: meta.name,
+        type: "built-in",
+        model: meta.model,
+        maxTurns: meta.maxTurns,
+        description: meta.description,
+        tools: meta.tools,
+        path: filePath,
+      });
+    }
+  }
+
+  // Custom agents
+  const customDir = getCustomAgentsDir();
+  if (existsSync(customDir)) {
+    for (const file of readdirSync(customDir).filter((f) => f.endsWith(".md"))) {
+      const filePath = join(customDir, file);
+      const { meta } = parseAgentFile(filePath);
+      agents.push({
+        name: meta.name,
+        type: "custom",
+        model: meta.model,
+        maxTurns: meta.maxTurns,
+        description: meta.description,
+        tools: meta.tools,
+        path: filePath,
+      });
+    }
+  }
+
+  return agents;
+}
+
+function findAgent(name: string): (AgentInfo & { body: string }) | null {
+  const agents = discoverAgents();
+  const agent = agents.find((a) => a.name === name);
+  if (!agent) return null;
+
+  const { body } = parseAgentFile(agent.path);
+  return { ...agent, body };
+}
+
+function isSymlinked(agentPath: string): boolean {
+  const claudeAgentsDir = getClaudeAgentsDir();
+  const linkPath = join(claudeAgentsDir, basename(agentPath));
+  if (!existsSync(linkPath)) return false;
+  try {
+    return lstatSync(linkPath).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+// --- Settings helpers ---
+
+function readSettingsFile(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeSettingsFile(path: string, settings: Record<string, unknown>): void {
+  const dir = join(path, "..");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const tmpPath = path + `.tmp.${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(settings, null, 2) + "\n");
+  renameSync(tmpPath, path);
+}
+
+function getGlobalSettingsPath(): string {
+  return join(homedir(), ".claude", "settings.json");
+}
+
+function getProjectSettingsPath(): string {
+  return join(process.cwd(), ".claude", "settings.json");
+}
+
+// --- Commands ---
+
+// team setup
+export interface TeamSetupOpts {
+  global?: boolean;
+  project?: boolean;
+  teammateMode?: string;
+  disable?: boolean;
+}
+
+export async function teamSetup(opts: TeamSetupOpts): Promise<void> {
+  const validModes = ["in-process", "tmux", "auto"];
+  const teammateMode = opts.teammateMode ?? "auto";
+
+  if (!validModes.includes(teammateMode)) {
+    errorResponse("INVALID_MODE", `Invalid teammate mode. Must be one of: ${validModes.join(", ")}`);
+  }
+
+  const scope = opts.project ? "project" : "global";
+  const settingsPath = opts.project ? getProjectSettingsPath() : getGlobalSettingsPath();
+
+  const settings = readSettingsFile(settingsPath);
+
+  if (opts.disable) {
+    // Remove agent teams config
+    const env = (settings.env ?? {}) as Record<string, string>;
+    delete env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS;
+    if (Object.keys(env).length === 0) {
+      delete settings.env;
+    } else {
+      settings.env = env;
+    }
+    delete settings.teammateMode;
+
+    writeSettingsFile(settingsPath, settings);
+    successResponse({ enabled: false, scope, path: settingsPath });
+    return;
+  }
+
+  // Enable agent teams
+  const env = ((settings.env ?? {}) as Record<string, string>);
+  env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+  settings.env = env;
+  settings.teammateMode = teammateMode;
+
+  writeSettingsFile(settingsPath, settings);
+  successResponse({ enabled: true, scope, teammateMode, path: settingsPath });
+}
+
+// team status
+export async function teamStatus(): Promise<void> {
+  const globalSettings = readSettingsFile(getGlobalSettingsPath());
+  const projectSettings = readSettingsFile(getProjectSettingsPath());
+
+  const globalEnv = (globalSettings.env ?? {}) as Record<string, string>;
+  const projectEnv = (projectSettings.env ?? {}) as Record<string, string>;
+
+  const globalEnabled = globalEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1";
+  const projectEnabled = projectEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1";
+  const enabled = globalEnabled || projectEnabled;
+
+  const teammateMode = (projectSettings.teammateMode ?? globalSettings.teammateMode ?? null) as string | null;
+
+  const scope = projectEnabled ? "project" : globalEnabled ? "global" : "none";
+
+  // Count agents
+  const builtInDir = getBuiltInAgentsDir();
+  const customDir = getCustomAgentsDir();
+  const builtInCount = existsSync(builtInDir)
+    ? readdirSync(builtInDir).filter((f) => f.endsWith(".md")).length
+    : 0;
+  const customCount = existsSync(customDir)
+    ? readdirSync(customDir).filter((f) => f.endsWith(".md")).length
+    : 0;
+
+  // Check symlink status
+  const agents = discoverAgents();
+  const claudeAgentsDir = getClaudeAgentsDir();
+  const allSynced = agents.every((a) => {
+    const linkPath = join(claudeAgentsDir, basename(a.path));
+    if (!existsSync(linkPath)) return false;
+    try {
+      return lstatSync(linkPath).isSymbolicLink();
+    } catch {
+      return false;
+    }
+  });
+
+  successResponse({
+    enabled,
+    teammateMode,
+    scope,
+    agents: {
+      builtIn: builtInCount,
+      custom: customCount,
+      synced: allSynced,
+    },
+  });
+}
+
+// team list
+export async function teamList(): Promise<void> {
+  const agents = discoverAgents();
+  successResponse(
+    agents.map((a) => ({
+      name: a.name,
+      type: a.type,
+      model: a.model,
+      maxTurns: a.maxTurns,
+      description: a.description,
+    }))
+  );
+}
+
+// team show
+export interface TeamShowOpts {
+  name: string;
+}
+
+export async function teamShow(opts: TeamShowOpts): Promise<void> {
+  if (!opts.name) {
+    errorResponse("MISSING_NAME", "Agent name is required (--name)");
+  }
+
+  const agent = findAgent(opts.name);
+  if (!agent) {
+    errorResponse("AGENT_NOT_FOUND", `Agent "${opts.name}" not found`);
+  }
+
+  successResponse({
+    name: agent.name,
+    type: agent.type,
+    model: agent.model,
+    tools: agent.tools,
+    maxTurns: agent.maxTurns,
+    description: agent.description,
+    instructions: agent.body,
+    path: agent.path,
+    symlinked: isSymlinked(agent.path),
+  });
+}
+
+// team create
+export interface TeamCreateOpts {
+  name: string;
+  description: string;
+  model?: string;
+  tools?: string;
+  maxTurns?: string;
+  instructions?: string;
+}
+
+export async function teamCreate(opts: TeamCreateOpts): Promise<void> {
+  if (!opts.name) {
+    errorResponse("MISSING_NAME", "Agent name is required (--name)");
+  }
+  if (!opts.description) {
+    errorResponse("MISSING_DESCRIPTION", "Agent description is required (--description)");
+  }
+
+  const validModels = ["sonnet", "opus", "haiku"];
+  const model = opts.model ?? "sonnet";
+  if (!validModels.includes(model)) {
+    errorResponse("INVALID_MODEL", `Invalid model. Must be one of: ${validModels.join(", ")}`);
+  }
+
+  // Check for name conflicts
+  const existing = discoverAgents();
+  if (existing.some((a) => a.name === opts.name)) {
+    errorResponse("AGENT_EXISTS", `Agent "${opts.name}" already exists`);
+  }
+
+  const tools = opts.tools ?? "Bash, Read, Grep, Glob";
+  const maxTurns = opts.maxTurns ? parseInt(opts.maxTurns, 10) : 15;
+
+  // Read instructions from file if provided
+  let body = "# Instructions\n\nAdd your agent instructions here.";
+  if (opts.instructions) {
+    if (!existsSync(opts.instructions)) {
+      errorResponse("FILE_NOT_FOUND", `Instructions file not found: ${opts.instructions}`);
+    }
+    body = readFileSync(opts.instructions, "utf-8").trim();
+  }
+
+  const meta: AgentMeta = {
+    name: opts.name,
+    description: opts.description,
+    tools,
+    model,
+    maxTurns,
+  };
+
+  ensureCustomAgentsDir();
+  const agentPath = join(getCustomAgentsDir(), `${opts.name}.md`);
+  writeFileSync(agentPath, generateAgentFile(meta, body));
+
+  // Symlink to ~/.claude/agents/
+  const claudeAgentsDir = getClaudeAgentsDir();
+  mkdirSync(claudeAgentsDir, { recursive: true });
+  const symlinkPath = join(claudeAgentsDir, `${opts.name}.md`);
+  if (existsSync(symlinkPath)) {
+    unlinkSync(symlinkPath);
+  }
+  symlinkSync(agentPath, symlinkPath);
+
+  successResponse({
+    created: true,
+    name: opts.name,
+    path: agentPath,
+    symlink: symlinkPath,
+  });
+}
+
+// team edit
+export interface TeamEditOpts {
+  name: string;
+  description?: string;
+  model?: string;
+  tools?: string;
+  maxTurns?: string;
+  instructions?: string;
+}
+
+export async function teamEdit(opts: TeamEditOpts): Promise<void> {
+  if (!opts.name) {
+    errorResponse("MISSING_NAME", "Agent name is required (--name)");
+  }
+
+  const agent = findAgent(opts.name);
+  if (!agent) {
+    errorResponse("AGENT_NOT_FOUND", `Agent "${opts.name}" not found`);
+  }
+  if (agent.type === "built-in") {
+    errorResponse("CANNOT_EDIT_BUILTIN", "Built-in agents cannot be edited. Create a custom agent instead.");
+  }
+
+  if (opts.model) {
+    const validModels = ["sonnet", "opus", "haiku"];
+    if (!validModels.includes(opts.model)) {
+      errorResponse("INVALID_MODEL", `Invalid model. Must be one of: ${validModels.join(", ")}`);
+    }
+  }
+
+  // Read existing file
+  const { meta, body: existingBody } = parseAgentFile(agent.path);
+
+  // Update only provided fields
+  const updatedMeta: AgentMeta = {
+    name: meta.name,
+    description: opts.description ?? meta.description,
+    tools: opts.tools ?? meta.tools,
+    model: opts.model ?? meta.model,
+    maxTurns: opts.maxTurns ? parseInt(opts.maxTurns, 10) : meta.maxTurns,
+  };
+
+  let body = existingBody;
+  if (opts.instructions) {
+    if (!existsSync(opts.instructions)) {
+      errorResponse("FILE_NOT_FOUND", `Instructions file not found: ${opts.instructions}`);
+    }
+    body = readFileSync(opts.instructions, "utf-8").trim();
+  }
+
+  writeFileSync(agent.path, generateAgentFile(updatedMeta, body));
+
+  successResponse({
+    updated: true,
+    name: opts.name,
+    changes: {
+      ...(opts.description && { description: opts.description }),
+      ...(opts.model && { model: opts.model }),
+      ...(opts.tools && { tools: opts.tools }),
+      ...(opts.maxTurns && { maxTurns: parseInt(opts.maxTurns, 10) }),
+      ...(opts.instructions && { instructions: "updated from file" }),
+    },
+  });
+}
+
+// team delete
+export interface TeamDeleteOpts {
+  name: string;
+}
+
+export async function teamDelete(opts: TeamDeleteOpts): Promise<void> {
+  if (!opts.name) {
+    errorResponse("MISSING_NAME", "Agent name is required (--name)");
+  }
+
+  const agent = findAgent(opts.name);
+  if (!agent) {
+    errorResponse("AGENT_NOT_FOUND", `Agent "${opts.name}" not found`);
+  }
+  if (agent.type === "built-in") {
+    errorResponse("CANNOT_DELETE_BUILTIN", "Built-in agents cannot be deleted.");
+  }
+
+  // Remove symlink from ~/.claude/agents/
+  const symlinkPath = join(getClaudeAgentsDir(), `${opts.name}.md`);
+  if (existsSync(symlinkPath)) {
+    unlinkSync(symlinkPath);
+  }
+
+  // Remove the agent file
+  unlinkSync(agent.path);
+
+  successResponse({
+    deleted: true,
+    name: opts.name,
+  });
+}
+
+// team sync
+export async function teamSync(): Promise<void> {
+  const agents = discoverAgents();
+  const claudeAgentsDir = getClaudeAgentsDir();
+  mkdirSync(claudeAgentsDir, { recursive: true });
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const agent of agents) {
+    const linkPath = join(claudeAgentsDir, basename(agent.path));
+
+    if (existsSync(linkPath)) {
+      try {
+        const stat = lstatSync(linkPath);
+        if (stat.isSymbolicLink()) {
+          // Check if symlink points to correct target
+          const target = readFileSync(linkPath, "utf-8");
+          // Re-create to ensure it points to the right place
+          unlinkSync(linkPath);
+          symlinkSync(agent.path, linkPath);
+          updated++;
+        } else {
+          // Regular file exists, replace with symlink
+          unlinkSync(linkPath);
+          symlinkSync(agent.path, linkPath);
+          updated++;
+        }
+      } catch {
+        unlinkSync(linkPath);
+        symlinkSync(agent.path, linkPath);
+        updated++;
+      }
+    } else {
+      symlinkSync(agent.path, linkPath);
+      created++;
+    }
+  }
+
+  successResponse({
+    synced: true,
+    total: agents.length,
+    created,
+    updated,
+    skipped,
+  });
+}

--- a/src/tools/shiba-cli/src/templates/claude-md.ts
+++ b/src/tools/shiba-cli/src/templates/claude-md.ts
@@ -1,0 +1,123 @@
+export const SHIBA_SECTION_START = "<!-- shiba-agent:start -->";
+export const SHIBA_SECTION_END = "<!-- shiba-agent:end -->";
+
+export type Platform = "github" | "gitlab" | "both";
+
+export interface ClaudeMdOptions {
+  platform: Platform;
+  issueTracker: "jira" | "github" | "gitlab";
+  repository: string;
+}
+
+export function generateShibaSection(opts: ClaudeMdOptions): string {
+  const lines: string[] = [
+    SHIBA_SECTION_START,
+    "",
+    "# Shiba Agent",
+    "",
+    "This project uses **shiba-agent** for VCS and issue tracking operations.",
+    "",
+    "## Important",
+    "",
+  ];
+
+  if (opts.platform === "github" || opts.platform === "both") {
+    lines.push(
+      "- **Do NOT use `gh` directly** — use `shiba github` commands instead"
+    );
+  }
+  if (opts.platform === "gitlab" || opts.platform === "both") {
+    lines.push(
+      "- **Do NOT use `glab` directly** — use `shiba gitlab` commands instead"
+    );
+  }
+  lines.push(
+    "- Use the shiba specialist agents (listed below) for complex operations"
+  );
+
+  lines.push("", "## Available Agents", "");
+
+  const agents: { name: string; description: string }[] = [];
+
+  if (opts.platform === "github" || opts.platform === "both") {
+    agents.push({
+      name: "github-agent",
+      description: "Pull requests, issues, code review",
+    });
+  }
+  if (opts.platform === "gitlab" || opts.platform === "both") {
+    agents.push({
+      name: "gitlab-agent",
+      description: "Merge requests, pipelines, code review",
+    });
+  }
+  if (opts.issueTracker === "jira") {
+    agents.push({
+      name: "jira-agent",
+      description: "Jira issues, transitions, JQL search",
+    });
+  }
+  agents.push(
+    {
+      name: "oapi-agent",
+      description: "OpenAPI endpoint discovery and schema analysis",
+    },
+    {
+      name: "project-manager",
+      description: "Orchestrates cross-system workflows",
+    },
+    {
+      name: "task-agent",
+      description: "Full task implementation from Jira tickets",
+    }
+  );
+
+  for (const agent of agents) {
+    lines.push(`- **${agent.name}** — ${agent.description}`);
+  }
+
+  lines.push("", "## Quick Reference", "");
+  lines.push("```bash");
+  lines.push("# Project setup");
+  lines.push("shiba init              # Detect repo and create .shiba/config.json");
+  lines.push("");
+
+  if (opts.platform === "github" || opts.platform === "both") {
+    lines.push("# GitHub");
+    lines.push("shiba github pr-create  --title \"...\" --body \"...\"");
+    lines.push("shiba github pr-list");
+    lines.push("shiba github pr-merge   --number 123");
+    lines.push("shiba github issue-list");
+    lines.push("");
+  }
+
+  if (opts.platform === "gitlab" || opts.platform === "both") {
+    lines.push("# GitLab");
+    lines.push(
+      `shiba gitlab mr-create  --project ${opts.repository} --source feat --target main --title "..."`
+    );
+    lines.push(`shiba gitlab mr-list    --project ${opts.repository}`);
+    lines.push(
+      `shiba gitlab mr-merge   --project ${opts.repository} --iid 123`
+    );
+    lines.push(`shiba gitlab issue-list --project ${opts.repository}`);
+    lines.push("");
+  }
+
+  if (opts.issueTracker === "jira") {
+    lines.push("# Jira");
+    lines.push("shiba jira issue-get    --key PROJ-123");
+    lines.push('shiba jira issue-search --jql "assignee = currentUser()"');
+    lines.push("shiba jira issue-transition --key PROJ-123 --transition \"In Progress\"");
+    lines.push("");
+  }
+
+  lines.push("# Branching & commits");
+  lines.push("shiba branch create     --key PROJ-123 --description \"short-desc\"");
+  lines.push('shiba commit-msg        --type feat --description "add feature"');
+  lines.push("```");
+
+  lines.push("", SHIBA_SECTION_END, "");
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

- Adds `shiba team` command with full CRUD for Claude Code agent definitions (setup, status, list, show, create, edit, delete, sync)
- Adds shared helpers `getCustomAgentsDir()` / `ensureCustomAgentsDir()` for per-environment custom agents in `data/agents/`
- Includes `shiba init` CLAUDE.md generation with managed section markers, and setup refactoring for reuse by `shiba update`

## Test plan

- [x] `bun run build` compiles successfully
- [x] `shiba team list` lists all 6 built-in agents with correct metadata
- [x] `shiba team show --name github-agent` returns full details + instructions
- [x] `shiba team create` creates custom agent file + symlink
- [x] `shiba team edit` updates only specified fields
- [x] `shiba team delete` removes file + symlink, rejects built-in
- [x] `shiba team setup` enables agent teams in settings.json (global/project)
- [x] `shiba team setup --disable` removes agent teams config
- [x] `shiba team status` reports enabled state, teammate mode, agent counts
- [x] `shiba team sync` re-creates symlinks for all agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)